### PR TITLE
Refactor ScriptT as a transformer transformer

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,30 @@
 Changelog for script-monad
 ==========================
 
+0.0.3.0
+-------
+
+This release has some significant changes to type names and signatures. The good news is that these changes make the code simpler and more modular. The bad news is that it now uses the `QuantifiedConstraints` extension, available only in GHC >=8.6.
+
+* Changed
+    * Most functions now have additional `Monad` and `MonadTrans` constraints.
+    * `ScriptT` is now `ScriptTT` and takes the effect monad as an explicit type parameter. Now acts like a monad transformer transformer.
+    * `Script` is now `ScriptT` and takes the effect monad as an explicit type parameter, reflecting its status as a monad transformer
+    * `HttpT` is now `HttpTT` and takes the effect monad as an explicit type parameter. Now acts like a monad transformer transformer.
+    * `Http` is now `HttpT` and takes the effect monad as an explicit type parameter, reflecting its status as a monad transformer
+    * `execScriptTM` is now `execScriptTT` and does not take an explicit `lift` parameter, using the generic `MonadTrans` instance instead.
+    * `checkScriptTM` is now `checkScriptTT` and does not take an explicit `lift` parameter, using the generic `MonadTrans` instance instead.
+    * `execHttpTM` is now `execHttpTT` and does not take an explicit `lift` parameter, using the generic `MonadTrans` instance instead.
+    * `checkHttpTM` is now `checkHttpTT` and does not take an explicit `lift` parameter, using the generic `MonadTrans` instance instead.
+* Removed
+    * `Script.lift`, in favor of a generic `MonadTrans` instance
+    * `liftHttpT`, in favor of a generic `MonadTrans` instance
+    * `execScriptT`, `execScript`, `checkScript`, and `checkScript`, which use a pure evaluator. These are subsumed by `ScriptTT` where the base monad is `Identity`.
+    * `execScriptM` and `checkScriptM`, which are subsumed by `ScriptTT` with the `IdentityT` transformer.
+    * `execHttpM` and `checkHttpM`, which are subsumed by `HttpTT` with the `IdentityT` transformer.
+
+
+
 0.0.2.1
 -------
 

--- a/script-monad.cabal
+++ b/script-monad.cabal
@@ -38,6 +38,7 @@ library
     , QuickCheck >=2.10.1
     , text >=1.2.3.0
     , time >=1.8.0.2
+    , transformers >=0.5.2.0
     , unordered-containers >=0.2.9.0
     , vector >=0.12.0.1
     , wreq >=0.5.2
@@ -82,6 +83,7 @@ test-suite script-monad-test
     , tasty-hunit >=0.10.0.1
     , tasty-quickcheck >=0.9.2
     , tasty-quickcheck-laws >= 0.0.1
+    , transformers >=0.5.2.0
 
   other-modules:
       Control.Monad.Script.Test

--- a/src/Control/Monad/Script.hs
+++ b/src/Control/Monad/Script.hs
@@ -1,31 +1,36 @@
 {- |
 Module      : Control.Monad.Script
-Description : An unrolled stack of Reader, Writer, Error, State, and Prompt.
+Description : An unrolled stack of Reader, Writer, Error, State, and Prompt transformers.
 Copyright   : 2018, Automattic, Inc.
 License     : BSD3
 Maintainer  : Nathan Bloomfield (nbloomf@gmail.com)
 Stability   : experimental
 Portability : POSIX
 
-`Script` is an unrolled stack of reader, writer, state, error, and prompt monads, meant as a basis for building more specific DSLs. Also comes in monad transformer flavor with `ScriptT`.
+`ScriptT` is an unrolled stack of reader, writer, state, error, and prompt monad transformers, meant as a basis for building more specific DSLs. Also comes in "monad transformer transformer" flavor with `ScriptTT`.
 
 The addition of prompt to the monad team makes it straightforward to build effectful computations which defer the actual effects (and effect types) to an evaluator function that is both precisely controlled and easily extended. This allows us to build testable and composable API layers.
 
-The name 'Script' is meant to evoke the script of a play. In the theater sense a script is not a list of /instructions/ so much as a list of /suggestions/, and every cast gives a unique interpretation. Similarly a 'Script' is a pure value that gets an effectful interpretation from a user-supplied evaluator.
+The name "script" is meant to evoke the script of a play. In the theater sense a script is not a list of /instructions/ so much as a list of /suggestions/, and every cast gives a unique interpretation. Similarly a 'ScriptT eff a' is a pure value that gets an effectful interpretation in monad `eff` from a user-supplied evaluator.
 -}
 
-{-# LANGUAGE Rank2Types, TupleSections, ScopedTypeVariables #-}
-module Control.Monad.Script (
-  -- * Script
-    Script
-  , execScript
-  , execScriptM
+{-#
+  LANGUAGE
+    GADTs,
+    Rank2Types,
+    TupleSections, 
+    KindSignatures,
+    ScopedTypeVariables,
+    QuantifiedConstraints
+#-}
 
+module Control.Monad.Script (
   -- * ScriptT
-  , ScriptT()
-  , execScriptT
-  , execScriptTM
-  , lift
+    ScriptT
+
+  -- * ScriptTT
+  , ScriptTT()
+  , execScriptTT
 
   -- * Error
   , except
@@ -57,16 +62,17 @@ module Control.Monad.Script (
   , prompt
 
   -- * Testing
-  , checkScript
-  , checkScriptM
-  , checkScriptT
-  , checkScriptTM
+  , checkScriptTT
 ) where
 
 
 
 import Control.Monad
   ( ap, join )
+import Control.Monad.Trans.Class
+  ( MonadTrans(..) )
+import Control.Monad.Trans.Identity
+  ( IdentityT(..) )
 import Data.Functor.Classes
   ()
 import Data.Functor.Identity
@@ -84,175 +90,115 @@ import Test.QuickCheck.Monadic
 
 
 
--- | Opaque transformer stack of error (@e@), reader (@r@), writer (@w@), state (@s@), and prompt (@p@) monads.
-newtype ScriptT e r w s p m a = ScriptT
-  { runScriptT
-      :: (s,r)
-      -> forall v.
-           ((Either e a, s, w) -> m v)
-        -> (forall u. p u -> (u -> m v) -> m v)
-        -> m v
-  } deriving Typeable
+-- | Opaque stack of error (@e@), reader (@r@), writer (@w@), state (@s@), and prompt (@p@) monad transformers, accepting a monad transformer parameter (@t@). Behaves something like a monad transformer transformer.
+data
+  ScriptTT
+    (e :: *)
+    (r :: *)
+    (w :: *)
+    (s :: *)
+    (p :: * -> *)
+    (t :: (* -> *) -> * -> *)
+    (eff :: * -> *)
+    (a :: *)
+  where
+  ScriptTT
+    :: (Monad eff, Monad (t eff), MonadTrans t)
+    => ((s,r)
+         -> forall v.
+             ((Either e a, s, w) -> t eff v)
+             -> (forall u. p u -> (u -> t eff v) -> t eff v)
+             -> t eff v)
+    -> ScriptTT e r w s p t eff a
+  deriving Typeable
 
-instance (Monoid w) => Monad (ScriptT e r w s p m) where
-  return x = ScriptT $ \(s,_) -> \end _ -> end (Right x, s, mempty)
+-- Only needed to make type inference work correctly.
+runScriptTT
+  :: ScriptTT e r w s p t eff a
+  -> (s,r)
+  -> forall v.
+     ((Either e a, s, w) -> t eff v)
+       -> (forall u. p u -> (u -> t eff v) -> t eff v)
+       -> t eff v
+runScriptTT (ScriptTT x) = x
 
-  x >>= f = ScriptT $ \(s0,r) -> \end cont -> do
+instance (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
+  => Monad (ScriptTT e r w s p t eff) where
+  return x = ScriptTT $ \(s,_) -> \end _ ->
+    end (Right x, s, mempty)
+
+  x >>= f = ScriptTT $ \(s0,r) -> \end cont -> do
     let
       g (z1,s1,w1) = case z1 of
         Right y -> do
           let h (z2,s2,w2) = end (z2, s2, mappend w1 w2)
-          runScriptT (f y) (s1,r) h cont
+          runScriptTT (f y) (s1,r) h cont
         Left e -> do
           let h (_,s2,w2) = end (Left e, s2, mappend w1 w2)
-          runScriptT (return ()) (s1,r) h cont
+          runScriptTT (return ()) (s1,r) h cont
           
-    runScriptT x (s0,r) g cont
+    runScriptTT x (s0,r) g cont
 
-instance (Monoid w) => Applicative (ScriptT e r w s p m) where
+instance (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
+  => Applicative (ScriptTT e r w s p t eff) where
   pure = return
   (<*>) = ap
 
-instance (Monoid w) => Functor (ScriptT e r w s p m) where
+instance (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
+  => Functor (ScriptTT e r w s p t eff) where
   fmap f x = x >>= (return . f)
 
-
-
-
-
--- | Opaque stack of error (@e@), reader (@r@), writer (@w@), state (@s@), and prompt (@p@) monads.
-type Script e r w s p = ScriptT e r w s p Identity
+instance (Monoid w, forall m. (Monad m) => Monad (t m), MonadTrans t)
+  => MonadTrans (ScriptTT e r w s p t) where
+  lift x = ScriptTT $ \(s,_) -> \end _ ->
+    lift x >>= \a -> end (Right a, s, mempty)
 
 
 
 
 
--- | Execute a 'ScriptT' with a specified initial state, environment, and continuation.
+-- | Opaque stack of error (@e@), reader (@r@), writer (@w@), state (@s@), and prompt (@p@) monad transformers.
+type ScriptT e r w s p = ScriptTT e r w s p IdentityT
+
+
+
+
+
+-- Execute a `ScriptTT` with a specified initial state, environment, and continuation.
 execScriptTC
   :: s -- ^ Initial state
   -> r -- ^ Environment
-  -> ((Either e a, s, w) -> m v)
-  -> (forall u. p u -> (u -> m v) -> m v)
-  -> ScriptT e r w s p m a
-  -> m v
-execScriptTC s r end cont x =
-  runScriptT x (s,r) end cont
+  -> ((Either e a, s, w) -> t eff v)
+  -> (forall u. p u -> (u -> t eff v) -> t eff v)
+  -> ScriptTT e r w s p t eff a
+  -> t eff v
+execScriptTC s r end cont (ScriptTT run) =
+  run (s,r) end cont
 
--- | Execute a 'ScriptT' with a specified initial state and environment, and with a pure evaluator.
-execScriptT
-  :: (Monad m)
-  => s -- ^ Initial state
-  -> r -- ^ Environment
-  -> (forall u. p u -> u) -- ^ Pure effect evaluator
-  -> ScriptT e r w s p m t
-  -> m (Either e t, s, w)
-execScriptT s r eval =
-  execScriptTC s r return (\p c -> c $ eval p)
-
--- | Turn a `ScriptT` with a pure evaluator into a `Property`; for testing with QuickCheck. Wraps `execScriptT`.
-checkScriptT
-  :: (Monad m)
-  => s -- ^ Initial state
-  -> r -- ^ Environment
-  -> (forall u. p u -> u) -- ^ Pure effect evaluator
-  -> (m (Either e t, s, w) -> IO q) -- ^ Condense to `IO`
-  -> (q -> Bool) -- ^ Result check
-  -> ScriptT e r w s p m t
-  -> Property
-checkScriptT s r eval cond check script = monadicIO $ do
-  let result = execScriptT s r eval script
-  q <- run $ cond result
-  assert $ check q
-
--- | Execute a 'ScriptT' with a specified inital state and environment, and with a monadic evaluator. In this case the inner monad @m@ will typically be a monad transformer over the effect monad @n@.
-execScriptTM
-  :: (Monad (m eff), Monad eff)
+-- | Execute a `ScriptTT` with a specified inital state and environment and with a specified prompt evaluator into the effect monad @eff@.
+execScriptTT
+  :: (Monad eff, Monad (t eff), MonadTrans t)
   => s -- ^ Initial state
   -> r -- ^ Environment
   -> (forall u. p u -> eff u) -- ^ Monadic effect evaluator
-  -> (forall u. eff u -> m eff u) -- ^ Lift effects to the inner monad
-  -> ScriptT e r w s p (m eff) t
-  -> m eff (Either e t, s, w)
-execScriptTM s r eval lift =
+  -> ScriptTT e r w s p t eff a
+  -> t eff (Either e a, s, w)
+execScriptTT s r eval =
   execScriptTC s r return
     (\p c -> (lift $ eval p) >>= c)
 
--- | Turn a `ScriptT` with a monadic evaluator into a `Property`; for testing with QuickCheck. Wraps `execScriptTM`.
-checkScriptTM
-  :: (Monad (m eff), Monad eff)
+-- | Turn a `ScriptTT` with a monadic evaluator into a `Property`; for testing with QuickCheck. Wraps `execScriptTT`.
+checkScriptTT
+  :: (Monad eff, Monad (t eff), MonadTrans t, Show q)
   => s -- ^ Initial state
   -> r -- ^ Environment
   -> (forall u. p u -> eff u) -- ^ Moandic effect evaluator
-  -> (forall u. eff u -> m eff u) -- ^ Lift effects to the inner monad
-  -> (m eff (Either e t, s, w) -> IO q) -- ^ Condense to `IO`
+  -> (t eff (Either e a, s, w) -> IO q) -- ^ Condense to `IO`
   -> (q -> Bool) -- ^ Result check
-  -> ScriptT e r w s p (m eff) t
+  -> ScriptTT e r w s p t eff a
   -> Property
-checkScriptTM s r eval lift cond check script = monadicIO $ do
-  let result = execScriptTM s r eval lift script
-  q <- run $ cond result
-  assert $ check q
-
-
-
--- | Execute a 'Script' with a specified initial state, environment, and continuation.
-execScriptC
-  :: s -- ^ Initial state
-  -> r -- ^ Environment
-  -> ((Either e a, s, w) -> v)
-  -> (forall u. p u -> (u -> v) -> v)
-  -> Script e r w s p a
-  -> v
-execScriptC s r end cont x =
-  let cont' p c = Identity $ cont p (runIdentity . c) in
-  runIdentity $ runScriptT x (s,r) (Identity . end) cont'
-
--- | Execute a 'Script' with a specified initial state and environment, and with a pure evaluator.
-execScript
-  :: s -- ^ Initial state
-  -> r -- ^ Environment
-  -> (forall u. p u -> u) -- ^ Pure evaluator
-  -> Script e r w s p t
-  -> (Either e t, s, w)
-execScript s r eval =
-  execScriptC s r id (\p c -> c $ eval p)
-
--- | Turn a `Script` with a pure evaluator into a `Bool`; for testing with QuickCheck. Wraps `execScript`.
-checkScript
-  :: s -- ^ Initial state
-  -> r -- ^ Environment
-  -> (forall u. p u -> u) -- ^ Pure evaluator
-  -> ((Either e t, s, w) -> q) -- ^ Condense
-  -> (q -> Bool) -- ^ Result check
-  -> Script e r w s p t
-  -> Bool
-checkScript s r eval cond check script =
-  check $ cond $ execScript s r eval script
-
--- | Execute a 'Script' with a specified inital state and environment, and with a monadic evaluator.
-execScriptM
-  :: (Monad eff)
-  => s -- ^ Initial state
-  -> r -- ^ Environment
-  -> (forall u. p u -> eff u) -- ^ Monadic evaluator
-  -> Script e r w s p t
-  -> eff (Either e t, s, w)
-execScriptM s r eval =
-  execScriptC s r return
-    (\p c -> (eval p) >>= c)
-
--- | Turn a `Script` with a monadic evaluator into a `Property`; for testing with QuickCheck. Wraps `execScriptM`.
-checkScriptM
-  :: (Monad eff)
-  => s -- ^ Initial state
-  -> r -- ^ Environment
-  -> (forall u. p u -> eff u) -- ^ Moandic effect evaluator
-  -> (eff (Either e t, s, w) -> IO q) -- ^ Condense to `IO`
-  -> (q -> Bool) -- ^ Result check
-  -> Script e r w s p t
-  -> Property
-checkScriptM s r eval cond check script = monadicIO $ do
-  let result = execScriptM s r eval script
+checkScriptTT s r eval cond check script = monadicIO $ do
+  let result = execScriptTT s r eval script
   q <- run $ cond result
   assert $ check q
 
@@ -260,234 +206,234 @@ checkScriptM s r eval cond check script = monadicIO $ do
 
 -- | Retrieve the environment.
 ask
-  :: (Monoid w)
-  => ScriptT e r w s p m r
-ask = ScriptT $ \(s,r) -> \end _ ->
+  :: (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
+  => ScriptTT e r w s p t eff r
+ask = ScriptTT $ \(s,r) -> \end _ ->
   end (Right r, s, mempty)
 
 
 
 -- | Run an action with a locally adjusted environment of the same type.
 local
-  :: (r -> r)
-  -> ScriptT e r w s p m a
-  -> ScriptT e r w s p m a
+  :: (Monad eff, Monad (t eff), MonadTrans t)
+  => (r -> r)
+  -> ScriptTT e r w s p t eff a
+  -> ScriptTT e r w s p t eff a
 local = transport
 
 
 
 -- | Run an action with a locally adjusted environment of a possibly different type.
 transport
-  :: (r2 -> r1)
-  -> ScriptT e r1 w s p m a
-  -> ScriptT e r2 w s p m a
-transport f x = ScriptT $ \(s,r) -> \end cont ->
-  runScriptT x (s, f r) end cont
+  :: (Monad eff, Monad (t eff), MonadTrans t)
+  => (r2 -> r1)
+  -> ScriptTT e r1 w s p t eff a
+  -> ScriptTT e r2 w s p t eff a
+transport f x = ScriptTT $ \(s,r) -> \end cont ->
+  runScriptTT x (s, f r) end cont
 
 
 
 -- | Retrieve the image of the environment under a given function.
 reader
-  :: (Monoid w)
+  :: (Monoid w, Monad eff, Monad (t eff), MonadTrans t, Monad (t eff))
   => (r -> a)
-  -> ScriptT e r w s p m a
+  -> ScriptTT e r w s p t eff a
 reader f = fmap f ask
 
 
 
 -- | Retrieve the current state.
 get
-  :: (Monoid w)
-  => ScriptT e r w s p m s
-get = ScriptT $ \(s,_) -> \end _ ->
+  :: (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
+  => ScriptTT e r w s p t eff s
+get = ScriptTT $ \(s,_) -> \end _ ->
   end (Right s, s, mempty)
 
 
 
 -- | Replace the state.
 put
-  :: (Monoid w)
+  :: (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
   => s
-  -> ScriptT e r w s p m ()
-put s = ScriptT $ \(_,_) -> \end _ ->
+  -> ScriptTT e r w s p t eff ()
+put s = ScriptTT $ \(_,_) -> \end _ ->
   end (Right (), s, mempty)
 
 
 
 -- | Modify the current state lazily.
 modify
-  :: (Monoid w)
+  :: (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
   => (s -> s)
-  -> ScriptT e r w s p m ()
-modify f = ScriptT $ \(s,_) -> \end _ ->
+  -> ScriptTT e r w s p t eff ()
+modify f = ScriptTT $ \(s,_) -> \end _ ->
   end (Right (), f s, mempty)
 
 
 
 -- | Modify the current state strictly.
 modify'
-  :: (Monoid w)
+  :: (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
   => (s -> s)
-  -> ScriptT e r w s p m ()
-modify' f = ScriptT $ \(s,_) -> \end _ ->
+  -> ScriptTT e r w s p t eff ()
+modify' f = ScriptTT $ \(s,_) -> \end _ ->
   end (Right (), f $! s, mempty)
 
 
 
 -- | Retrieve the image of the current state under a given function.
 gets
-  :: (Monoid w)
+  :: (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
   => (s -> a)
-  -> ScriptT e r w s p m a
-gets f = ScriptT $ \(s,_) -> \end _ ->
+  -> ScriptTT e r w s p t eff a
+gets f = ScriptTT $ \(s,_) -> \end _ ->
   end (Right (f s), s, mempty)
 
 
 
 -- | Write to the log.
 tell
-  :: w
-  -> ScriptT e r w s p m ()
-tell w = ScriptT $ \(s,_) -> \end _ ->
+  :: (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
+  => w
+  -> ScriptTT e r w s p t eff ()
+tell w = ScriptTT $ \(s,_) -> \end _ ->
   end (Right (), s, w)
 
 
 
 -- | Run an action and attach the log to the result, setting the log to `mempty`.
 draft
-  :: (Monoid w)
-  => ScriptT e r w s p m a
-  -> ScriptT e r w s p m (a,w)
-draft x = ScriptT $ \(r,s) -> \end cont ->
-  runScriptT x (r,s)
+  :: (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
+  => ScriptTT e r w s p t eff a
+  -> ScriptTT e r w s p t eff (a,w)
+draft x = ScriptTT $ \(r,s) -> \end cont ->
+  runScriptTT x (r,s)
     (\(y,s,w) -> end (fmap (,w) y, s, mempty)) cont
 
 
 
 -- | Run an action and attach the log to the result.
 listen
-  :: ScriptT e r w s p m a
-  -> ScriptT e r w s p m (a,w)
-listen x = ScriptT $ \(r,s) -> \end cont ->
-  runScriptT x (r,s)
+  :: (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
+  => ScriptTT e r w s p t eff a
+  -> ScriptTT e r w s p t eff (a,w)
+listen x = ScriptTT $ \(r,s) -> \end cont ->
+  runScriptTT x (r,s)
     (\(y,s,w) -> end (fmap (,w) y, s, w)) cont
 
 
 
 -- | Run an action that returns a value and a log-adjusting function, and apply the function to the local log.
 pass
-  :: ScriptT e r w s p m (a, w -> w)
-  -> ScriptT e r w s p m a
-pass x = ScriptT $ \(r,s) -> \end cont ->
+  :: (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
+  => ScriptTT e r w s p t eff (a, w -> w)
+  -> ScriptTT e r w s p t eff a
+pass x = ScriptTT $ \(r,s) -> \end cont ->
   let
     end' (z,s1,w) = case z of
       Right (y,f) -> end (Right y, s1, f w)
       Left e -> end (Left e, s1, w)
   in
-    runScriptT x (r,s) end' cont
+    runScriptTT x (r,s) end' cont
 
 
 
 -- | Run an action, applying a function to the local log.
 censor
-  :: (w -> w)
-  -> ScriptT e r w s p m a
-  -> ScriptT e r w s p m a
-censor f x = pass $ ScriptT $ \(s,r) -> \end cont ->
+  :: (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
+  => (w -> w)
+  -> ScriptTT e r w s p t eff a
+  -> ScriptTT e r w s p t eff a
+censor f x = pass $ ScriptTT $ \(s,r) -> \end cont ->
   let
     end' (z,s1,w) = case z of
       Right y -> end (Right (y,f), s1, w)
       Left e -> end (Left e, s1, w)
   in
-    runScriptT x (s,r) end' cont
+    runScriptTT x (s,r) end' cont
 
 
 
 -- | Inject an 'Either' into a 'Script'.
 except
-  :: (Monoid w)
+  :: (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
   => Either e a
-  -> ScriptT e r w s p m a
-except z = ScriptT $ \(s,_) -> \end _ ->
+  -> ScriptTT e r w s p t eff a
+except z = ScriptTT $ \(s,_) -> \end _ ->
   end (z, s, mempty)
 
 
 
 -- | Run an action, applying a function to any error.
 triage
-  :: (Monoid w)
+  :: (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
   => (e1 -> e2)
-  -> ScriptT e1 r w s p m a
-  -> ScriptT e2 r w s p m a
-triage f x = ScriptT $ \(s,r) -> \end cont ->
+  -> ScriptTT e1 r w s p t eff a
+  -> ScriptTT e2 r w s p t eff a
+triage f x = ScriptTT $ \(s,r) -> \end cont ->
   let
     end' (z,s1,w) = case z of
       Right y -> end (Right y, s1, w)
       Left e -> end (Left (f e), s1, w)
   in
-    runScriptT x (s,r) end' cont
+    runScriptTT x (s,r) end' cont
 
 
 
 -- | Raise an error.
 throw
-  :: (Monoid w)
+  :: (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
   => e
-  -> ScriptT e r w s p m a
-throw e = ScriptT $ \(s,r) -> \end cont ->
+  -> ScriptTT e r w s p t eff a
+throw e = ScriptTT $ \(s,r) -> \end cont ->
   let end' (_,s1,w1) = end (Left e, s1, w1)
-  in runScriptT (return ()) (s,r) end' cont
+  in runScriptTT (return ()) (s,r) end' cont
 
 
 
 -- | Run an action, applying a handler in case of an error result.
 catch
-  :: (Monoid w)
-  => ScriptT e r w s p m a
-  -> (e -> ScriptT e r w s p m a)
-  -> ScriptT e r w s p m a
-catch x h = ScriptT $ \(s,r) -> \end cont ->
+  :: (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
+  => ScriptTT e r w s p t eff a
+  -> (e -> ScriptTT e r w s p t eff a)
+  -> ScriptTT e r w s p t eff a
+catch (ScriptTT x) h = ScriptTT $ \(s,r) -> \end cont ->
   let
     end' (z,s1,w) = case z of
       Right y -> end (Right y, s1, w)
       Left e -> do
         let end'' (z2,s2,w2) = end (z2, s2, mappend w w2)
-        runScriptT (h e) (s1,r) end'' cont
+        runScriptTT (h e) (s1,r) end'' cont
   in
-    runScriptT x (s,r) end' cont
+    x (s,r) end' cont
 
 
 
 -- | Inject an atomic effect.
 prompt
-  :: (Monoid w)
+  :: (Monoid w, Monad eff, Monad (t eff), MonadTrans t)
   => p a
-  -> ScriptT e r w s p m a
-prompt p = ScriptT $ \(s,_) -> \end cont ->
+  -> ScriptTT e r w s p t eff a
+prompt p = ScriptTT $ \(s,_) -> \end cont ->
   cont p (\a -> end (Right a, s, mempty))
 
 
 
--- | Lift a computation in the base monad.
-lift
-  :: (Monoid w, Monad m)
-  => m a
-  -> ScriptT e r w s p m a
-lift x = ScriptT $ \(s,_) -> \end _ ->
-  x >>= \a -> end (Right a, s, mempty)
 
 
-
-instance (Monad m, Monoid w, Arbitrary a, CoArbitrary a)
-  => Arbitrary (ScriptT e r w s p m a) where
+instance
+  ( Monoid w, Monad eff, forall m. Monad m => Monad (t m), MonadTrans t
+  , Arbitrary a, CoArbitrary a
+  ) => Arbitrary (ScriptTT e r w s p t eff a) where
   arbitrary = do
     (a,b) <- arbitrary :: Gen (a,a)
     k <- arbitrary :: Gen Int
     if k`rem`2 == 0
       then return $ return a
       else do
-        f <- arbitrary :: Gen (a -> ScriptT e r w s p m a)
+        f <- arbitrary :: Gen (a -> ScriptTT e r w s p t eff a)
         return $ f a >> lift (return b)
 
-instance Show (ScriptT e r w s p m a) where
+instance Show (ScriptTT e r w s p t eff a) where
   show _ = "<Script>"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.11
+resolver: nightly-2018-12-20
 
 packages:
 - .

--- a/test/Control/Monad/Script/Test.hs
+++ b/test/Control/Monad/Script/Test.hs
@@ -3,6 +3,7 @@ module Control.Monad.Script.Test (
   tests
 ) where
 
+import Control.Monad.Trans.Identity
 import Data.Proxy
 import Data.Functor.Classes
 import Data.Functor.Identity
@@ -112,25 +113,25 @@ tests num =
 
 
 
--- | `ScriptT` values are pure, so we can test them for equality.
+-- | `ScriptTT` values are pure, so we can test them for equality.
 scriptEq
-  :: (Monad m, Eq a, Eq e, Eq s, Eq w, Eq1 m)
-  => (forall u. p u -> u)
+  :: (Monad eff, Eq a, Eq e, Eq s, Eq w, Eq1 eff)
+  => (forall u. p u -> eff u)
   -> (s, r)
-  -> ScriptT e r w s p m a
-  -> ScriptT e r w s p m a
+  -> ScriptTT e r w s p IdentityT eff a
+  -> ScriptTT e r w s p IdentityT eff a
   -> Bool
 scriptEq eval (s,r) sc1 sc2 =
   liftEq (==)
-    (execScriptT s r eval sc1)
-    (execScriptT s r eval sc2)
+    (execScriptTT s r eval sc1)
+    (execScriptTT s r eval sc2)
 
 
 
 data Q a = Q a
 
-evalQ :: Q a -> a
-evalQ (Q a) = a
+evalQ :: (Monad eff) => Q a -> eff a
+evalQ (Q a) = return a
 
 pQ = Proxy :: Proxy Q
 
@@ -145,8 +146,8 @@ pLs = Proxy :: Proxy []
 pEi = Proxy :: Proxy (Either Int)
 
 pSc
-  :: Proxy e -> Proxy r -> Proxy w -> Proxy s -> Proxy p -> Proxy m
-  -> Proxy (ScriptT e r w s p m)
+  :: Proxy e -> Proxy r -> Proxy w -> Proxy s -> Proxy p -> Proxy eff
+  -> Proxy (ScriptTT e r w s p IdentityT eff)
 pSc _ _ _ _ _ _ = Proxy
 
 pSt


### PR DESCRIPTION
This renames `ScriptT` to `ScriptTT` and changes its type to include the effect monad type constructor, which sort of makes `ScriptTT` a monad transformer transformer. This is handy for stacking multiple API clients together. Say we've got clients implemented in terms of `ScriptTT`, called `FooTT` and `BarTT`; then we can compose them with

```
type QuxT m a = FooTT (BarTT IdentityT) m a
```

where `m` is the effect type (e.g. `IO` or `StateT s IO`).