### PR TITLE
Remove eq instance from HttpResponse to compile with http-client

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,13 @@
 Changelog for script-monad
 ==========================
 
+0.0.3.1
+-------
+* Removed
+    * `Eq` instance for `HttpResponse`, see
+    https://github.com/snoyberg/http-client/issues/433
+
+
 0.0.3
 -----
 

--- a/src/Network/HTTP/Client/Extras.hs
+++ b/src/Network/HTTP/Client/Extras.hs
@@ -53,7 +53,7 @@ data HttpResponse = HttpResponse
   , _responseHeaders :: ResponseHeaders
   , _responseBody :: ByteString
   , _responseCookieJar :: CookieJar
-  } deriving (Eq, Show)
+  } deriving (Show)
 
 -- | Convert an opaque `Response ByteString` into an `HttpResponse`.
 readHttpResponse :: Response ByteString -> HttpResponse


### PR DESCRIPTION
After http-client >=0.7.0, the instance for Eq was removed from Cookie, which is a field of the HttpResponse.